### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/main/store/PersistentStoreController.js
+++ b/main/store/PersistentStoreController.js
@@ -1,4 +1,4 @@
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const {List, Set} = require('immutable')
 
 const {ObservableEvent, bindFunctions} = require('lsd-observable')

--- a/main/util/EntityManager.js
+++ b/main/util/EntityManager.js
@@ -1,4 +1,4 @@
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 
 module.exports = class EntityManager {
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "immutable": "^3.8.1",
     "lodash": "^4.15.0",
     "lsd-observable": "^0.1.1",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",

--- a/test/functional/PersistentStoreBrowserSpec.js
+++ b/test/functional/PersistentStoreBrowserSpec.js
@@ -4,7 +4,7 @@ const {PersistentStore, LocalUpdateStore, AccessKeyCredentialsSource, S3UpdateSt
 const {capture, waitFor} = require('../testutil/Helpers')
 const TestS3Store = require('../testutil/TestS3Store')
 const TestItem = require('../testutil/TestItem')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const _ = require('lodash')
 const fs = require('fs')
 

--- a/test/store/StateControllerSpec.js
+++ b/test/store/StateControllerSpec.js
@@ -3,7 +3,7 @@ const chai = require('chai'),
     sinon = require("sinon"),
     sinonChai = require("sinon-chai"),
     _ = require('lodash'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     {capture, captureFlat} = require('../testutil/Helpers')
     StateController = require('../../main/store/StateController')
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.